### PR TITLE
Add health check

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,10 @@ func main() {
 		bot.WithTestGuildID(id)
 	}
 
+	if addr := os.Getenv("HEALTH_CHECK_ADDR"); addr != "" {
+		bot.WithHealthCheck(addr)
+	}
+
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 

--- a/internal/tests/health_stage_test.go
+++ b/internal/tests/health_stage_test.go
@@ -1,0 +1,66 @@
+package tests
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/elliotwms/pinbot/internal/pinbot"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"os"
+	"testing"
+)
+
+type HealthStage struct {
+	t       *testing.T
+	session *discordgo.Session
+	require *require.Assertions
+	assert  *assert.Assertions
+	logHook *test.Hook
+	res     *http.Response
+}
+
+func NewHealthStage(t *testing.T) (*HealthStage, *HealthStage, *HealthStage) {
+	log := logrus.New()
+
+	s := &HealthStage{
+		t:       t,
+		session: session,
+		require: require.New(t),
+		assert:  assert.New(t),
+		logHook: test.NewLocal(log),
+	}
+
+	done := make(chan os.Signal, 1)
+
+	go func() {
+		bot := pinbot.New(session, log)
+		s.require.NoError(bot.WithHealthCheck(":8080").Run(done))
+	}()
+
+	t.Cleanup(func() {
+		done <- os.Interrupt
+	})
+
+	return s, s, s
+}
+
+func (s *HealthStage) and() *HealthStage {
+	return s
+}
+
+func (s *HealthStage) the_bot_is_running() *HealthStage {
+	return s // no-op
+}
+
+func (s *HealthStage) a_health_check_request_is_sent() {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/v1/health", nil)
+	s.require.NoError(err)
+	s.res, err = http.DefaultClient.Do(req)
+	s.require.NoError(err)
+}
+
+func (s *HealthStage) a_response_should_be_received_with_status_code(code int) {
+	s.require.Equal(code, s.res.StatusCode)
+}

--- a/internal/tests/health_stage_test.go
+++ b/internal/tests/health_stage_test.go
@@ -46,10 +46,6 @@ func NewHealthStage(t *testing.T) (*HealthStage, *HealthStage, *HealthStage) {
 	return s, s, s
 }
 
-func (s *HealthStage) and() *HealthStage {
-	return s
-}
-
 func (s *HealthStage) the_bot_is_running() *HealthStage {
 	return s // no-op
 }

--- a/internal/tests/health_test.go
+++ b/internal/tests/health_test.go
@@ -1,0 +1,14 @@
+package tests
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestHealth(t *testing.T) {
+	given, when, then := NewHealthStage(t)
+
+	given.the_bot_is_running()
+	when.a_health_check_request_is_sent()
+	then.a_response_should_be_received_with_status_code(http.StatusOK)
+}


### PR DESCRIPTION
Add a configurable health check endpoint, which returns 200 if a heartbeat response has been received in the last 5 minutes
