### PR TITLE
Trigger channel import on new classic pins

### DIFF
--- a/internal/eventhandlers/channel_pins_update.go
+++ b/internal/eventhandlers/channel_pins_update.go
@@ -1,0 +1,16 @@
+package eventhandlers
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/elliotwms/pinbot/internal/commandhandlers"
+	"github.com/sirupsen/logrus"
+)
+
+func ChannelPinsUpdate(log *logrus.Entry) func(s *discordgo.Session, e *discordgo.ChannelPinsUpdate) {
+	return func(s *discordgo.Session, e *discordgo.ChannelPinsUpdate) {
+		commandhandlers.ImportChannelCommandHandler(&commandhandlers.ImportChannelCommand{
+			ChannelID: e.ChannelID,
+			GuildID:   e.GuildID,
+		}, s, log)
+	}
+}

--- a/internal/pinbot/configure.go
+++ b/internal/pinbot/configure.go
@@ -15,6 +15,7 @@ func (bot *Bot) registerHandlers() func() {
 		bot.session.AddHandler(eventhandlers.ChannelUpdate(bot.log.WithField(logFieldHandler, "ChannelUpdate"))),
 		bot.session.AddHandler(eventhandlers.ChannelDelete(bot.log.WithField(logFieldHandler, "ChannelDelete"))),
 		bot.session.AddHandler(eventhandlers.InteractionCreate(bot.log.WithField(logFieldHandler, "InteractionCreate"))),
+		bot.session.AddHandler(eventhandlers.ChannelPinsUpdate(bot.log.WithField(logFieldHandler, "ChannelPinsUpdate"))),
 	}
 
 	return func() {

--- a/internal/tests/pin_stage_test.go
+++ b/internal/tests/pin_stage_test.go
@@ -226,8 +226,10 @@ func (s *PinStage) the_bot_should_log_the_message_as_an_avoided_self_pin() {
 	}, 1*time.Second, 10*time.Millisecond)
 }
 
-func (s *PinStage) the_message_is_pinned() {
+func (s *PinStage) the_message_is_pinned() *PinStage {
 	s.require.NoError(s.session.ChannelMessagePin(s.channel.ID, s.message.ID))
+
+	return s
 }
 
 func (s *PinStage) an_import_is_triggered() {
@@ -278,6 +280,17 @@ func (s *PinStage) the_pin_message_should_have_n_embeds_with_url(n int) {
 
 func (s *PinStage) the_pin_message_should_have_n_embeds(n int) *PinStage {
 	s.require.Len(s.pinMessage.Embeds, n)
+
+	return s
+}
+
+func (s *PinStage) the_import_is_cleaned_up() *PinStage {
+	s.a_pin_message_should_be_posted_in_the_last_channel()
+
+	s.require.NoError(s.session.ChannelMessageDelete(s.pinMessage.ChannelID, s.pinMessage.ID))
+	s.messages = []*discordgo.Message{}
+
+	s.require.NoError(s.session.MessageReactionsRemoveAll(s.message.ChannelID, s.message.ID))
 
 	return s
 }

--- a/internal/tests/pin_test.go
+++ b/internal/tests/pin_test.go
@@ -82,13 +82,30 @@ func TestPinSelfPinDisabled(t *testing.T) {
 		the_bot_should_log_the_message_as_an_avoided_self_pin()
 }
 
+func TestPinClassicPinTriggersChannelImport(t *testing.T) {
+	given, when, then := NewPinStage(t)
+
+	given.
+		a_channel_named("test").and().
+		the_message_is_posted()
+
+	when.
+		the_message_is_pinned()
+
+	then.
+		a_pin_message_should_be_posted_in_the_last_channel().and().
+		the_bot_should_add_the_emoji("👀").and().
+		the_bot_should_add_the_emoji("✅")
+}
+
 func TestPinImportCommand(t *testing.T) {
 	given, when, then := NewPinStage(t)
 
 	given.
 		a_channel_named("test").and().
 		the_message_is_posted().and().
-		the_message_is_pinned()
+		the_message_is_pinned().and().
+		the_import_is_cleaned_up()
 
 	when.
 		an_import_is_triggered()
@@ -111,9 +128,7 @@ func TestPinImportCommandIgnoreAlreadyPinned(t *testing.T) {
 		an_import_is_triggered()
 
 	then.
-		a_pin_message_should_be_posted_in_the_last_channel().and().
-		the_bot_should_add_the_emoji("👀").and().
-		the_bot_should_add_the_emoji("✅")
+		the_bot_should_log_the_message_as_already_pinned()
 }
 
 func TestPinWithImage(t *testing.T) {


### PR DESCRIPTION
Closes #19 

feat: trigger channel import on new classic pins
fix: TestPinImportCommandIgnoreAlreadyPinned
